### PR TITLE
Reference QOI codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Other repositories about PHP FFI:
 - [SDL Image bindings for PHP](https://github.com/SerafimArts/ffi-sdl-ttf)
 - [PHP-IUP Gui ToolKit using FFI](https://github.com/ghostjat/php-iup)
 - [Shooter game written using PHP 7.4 FFI](https://github.com/darkin1/PhpShooter)
+- [QOI Image encoder](https://github.com/MKCG/php-qoi)
 
 PHP FFI tricks:
 


### PR DESCRIPTION
I made a QOI Codec in PHP.

This codec use a FFI when the library detects that the CPU is based on the x86_64 architecture, otherwise it fallbacks on a plain PHP implementation.

Source :
- [Detection of the CPU architecture](https://github.com/MKCG/php-qoi/blob/main/src/Codec.php#L47)
- [Usage of the FFI extension](https://github.com/MKCG/php-qoi/blob/4ed1f18e95227702763c08c0395e72160cfdec8a/src/FFI/x86.php#L35)
- [Definition of the C library](https://github.com/MKCG/php-qoi/tree/4ed1f18e95227702763c08c0395e72160cfdec8a/src/FFI/lib)
- [Shared objects](https://github.com/MKCG/php-qoi/tree/4ed1f18e95227702763c08c0395e72160cfdec8a/src/FFI/bin)